### PR TITLE
chore: update dependencies and router initialization

### DIFF
--- a/bin/wfrouter.js
+++ b/bin/wfrouter.js
@@ -11,7 +11,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const program = new Command();
 
-const LATEST_WEBFLOW_ROUTER_VERSION = "0.1.6";
+const LATEST_WEBFLOW_ROUTER_VERSION = "0.1.15";
 
 // --- INIT COMMAND ---
 async function initProject(projectNameArg, options) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wfrouter",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "CLI to set up a new Vite project with Webflow Router Kit.",
   "type": "module",
   "bin": {
@@ -26,7 +26,7 @@
     "execa": "^8.0.1",
     "fs-extra": "^11.3.0",
     "inquirer": "^9.3.7",
-    "webflow-router": "^0.1.3"
+    "webflow-router": "^0.1.15"
   },
   "engines": {
     "node": ">=16"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^9.3.7
         version: 9.3.7
       webflow-router:
-        specifier: ^0.1.3
-        version: 0.1.4
+        specifier: ^0.1.15
+        version: 0.1.15
 
 packages:
 
@@ -294,8 +294,8 @@ packages:
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
-  webflow-router@0.1.4:
-    resolution: {integrity: sha512-VjyiO3EYbIjYEUSd/d7Lh5YWrY9rP6Wte66pk+i09c7kI2nLZK0DTTCeIkW+WjgmDm7X7ZPcU+9M/JxFkclWAw==}
+  webflow-router@0.1.15:
+    resolution: {integrity: sha512-8rvXbv7wP9+IFW3qZk8zpP34/uke2OUmhXlfs24F9dpdyJNLOj0wvxISd2nHHKxIEJ0RpYHKnkCPE8JywSRPzg==}
     hasBin: true
 
   which@2.0.2:
@@ -564,7 +564,7 @@ snapshots:
     dependencies:
       defaults: 1.0.4
 
-  webflow-router@0.1.4:
+  webflow-router@0.1.15:
     dependencies:
       '@vue/reactivity': 3.5.16
 

--- a/templates/vite-ts/src/main.ts
+++ b/templates/vite-ts/src/main.ts
@@ -2,12 +2,12 @@ import { WebflowRouter } from "webflow-router";
 import type { RouterOptions } from "webflow-router";
 import { generatedRoutes } from "./generated-wf-routes";
 
-const isProd = import.meta.env.PROD;
+const routerOptions: RouterOptions = {};
 
-const routerOptions: RouterOptions = {
-  pageScriptBasePath: isProd ? "/pages" : "/src/pages",
-};
-
-const router = new WebflowRouter(generatedRoutes, routerOptions);
+const router = new WebflowRouter(
+  generatedRoutes,
+  import.meta.env.PROD,
+  routerOptions
+);
 
 router.start();


### PR DESCRIPTION
Bump wfrouter version to 0.1.5 and update webflow-router dependency to 0.1.15 to align with the latest features and fixes.

Modify wfrouter CLI to reflect the updated webflow-router version.

Refactor router initialization in the Vite template to pass import.meta.env.PROD as a separate argument and simplify routerOptions, improving clarity and compatibility with the updated webflow-router API.