### PR TITLE
chore: update project init to use slugified project name

### DIFF
--- a/bin/wfrouter.js
+++ b/bin/wfrouter.js
@@ -6,12 +6,13 @@ import fs from "fs-extra";
 import path from "path";
 import { fileURLToPath } from "url";
 import { execa } from "execa";
+import slugify from "slugify";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const program = new Command();
 
-const LATEST_WEBFLOW_ROUTER_VERSION = "0.1.15";
+const LATEST_WEBFLOW_ROUTER_VERSION = "0.1.21";
 
 // --- INIT COMMAND ---
 async function initProject(projectNameArg, options) {
@@ -88,6 +89,7 @@ async function initProject(projectNameArg, options) {
     );
     let packageJsonContent = packageJsonTemplate
       .replace("{{PROJECT_NAME}}", projectName)
+      .replace("{{PROJECT_SLUG}}", slugify(projectName, { lower: true }))
       .replace('"VERSION_PLACEHOLDER"', `"^${LATEST_WEBFLOW_ROUTER_VERSION}"`);
     await fs.writeFile(
       path.join(projectPath, "package.json"),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wfrouter",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "CLI to set up a new Vite project with Webflow Router Kit.",
   "type": "module",
   "bin": {
@@ -25,6 +25,7 @@
     "execa": "^8.0.1",
     "fs-extra": "^11.3.0",
     "inquirer": "^9.3.7",
+    "slugify": "^1.6.6",
     "webflow-router": "^0.1.15"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       inquirer:
         specifier: ^9.3.7
         version: 9.3.7
+      slugify:
+        specifier: ^1.6.6
+        version: 1.6.6
       webflow-router:
         specifier: ^0.1.15
         version: 0.1.15
@@ -253,6 +256,10 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  slugify@1.6.6:
+    resolution: {integrity: sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==}
+    engines: {node: '>=8.0.0'}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -527,6 +534,8 @@ snapshots:
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
+
+  slugify@1.6.6: {}
 
   string-width@4.2.3:
     dependencies:

--- a/templates/vite-ts/package.json.template
+++ b/templates/vite-ts/package.json.template
@@ -8,8 +8,8 @@
     "build": "npm run generate-routes && tsc && vite build",
     "preview": "vite preview",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "generate-routes": "generate-webflow-routes --pages-dir=src/app-pages --output-dir=src --output-file=generated-wf-routes.ts",
-    "deploy": "pnpx wrangler pages deploy dist --project-name {{PROJECT_NAME}} --branch main"
+    "generate-routes": "generate-webflow-routes --pages-dir=src/pages --output-dir=src --output-file=generated-wf-routes.ts",
+    "deploy": "pnpx wrangler pages deploy dist --project-name {{PROJECT_SLUG}} --branch main"
   },
   "dependencies": {
     "webflow-router": "VERSION_PLACEHOLDER",


### PR DESCRIPTION
- bump wfrouter and webflow-router versions to latest releases
- add slugify dependency to generate URL-friendly project slugs
- update package.json template to replace project slug placeholder
- modify deploy script to use slugified project name for consistency

These changes improve project setup by ensuring valid slugs are used   in deployment and configuration, reducing potential errors with names.