### PR TITLE
fix: update package scripts to use pnpm and bump router version

### DIFF
--- a/bin/wfrouter.js
+++ b/bin/wfrouter.js
@@ -12,7 +12,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const program = new Command();
 
-const LATEST_WEBFLOW_ROUTER_VERSION = "0.1.21";
+const LATEST_WEBFLOW_ROUTER_VERSION = "0.1.28";
 
 // --- INIT COMMAND ---
 async function initProject(projectNameArg, options) {

--- a/templates/vite-ts/package.json.template
+++ b/templates/vite-ts/package.json.template
@@ -4,8 +4,8 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "npm run generate-routes && vite",
-    "build": "npm run generate-routes && tsc && vite build",
+    "dev": "pnpm run generate-routes && vite",
+    "build": "pnpm run generate-routes && tsc && vite build",
     "preview": "vite preview",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "generate-routes": "generate-webflow-routes --pages-dir=src/pages --output-dir=src --output-file=generated-wf-routes.ts",


### PR DESCRIPTION
Change package.json scripts from npm to pnpm to improve consistency and performance in the vite-ts template. Update the latest webflow router version from 0.1.21 to 0.1.28 to ensure the project uses the newest fixes and features.