### PR TITLE
chore: bump wfrouter and Webflow Router versions

### DIFF
--- a/bin/wfrouter.js
+++ b/bin/wfrouter.js
@@ -12,7 +12,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const program = new Command();
 
-const LATEST_WEBFLOW_ROUTER_VERSION = "0.1.28";
+const LATEST_WEBFLOW_ROUTER_VERSION = "0.1.30";
 
 // --- INIT COMMAND ---
 async function initProject(projectNameArg, options) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wfrouter",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "CLI to set up a new Vite project with Webflow Router Kit.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Update wfrouter version to 0.1.8 and set the latest Webflow
Router version to 0.1.30. These changes ensure the uses
the most recent stable dependencies new Vite projects.